### PR TITLE
답변용 이슈 템플릿 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/topic-answer.md
+++ b/.github/ISSUE_TEMPLATE/topic-answer.md
@@ -1,0 +1,24 @@
+---
+name: topic-answer
+about: 질문에 대한 답변 남기는 템플릿
+title: "[OS] 1. ContextSwitch에 대해서 설명해주세요."
+labels: ''
+assignees: ''
+
+---
+
+## [Topic](링크) <----- 핵심 주제 공지 Issue를 링크해주세요.  
+ - #주차 핵심 주제 면접 스터디 
+
+## 1. ContextSwitch에 대해서 설명해주세요.
+
+### 키워드 
+
+`PCB`, `인터럽트`
+
+----------------------
+
+> 체크 리스트
+> 1. assignee에 본인을 등록해주세요. 
+> 2. 핵심 주제 공지 Issue 질문에 해당 Issue를 링크해주세요. 
+> 3. 관련한 주제가 있다면 label을 부착해주세요.


### PR DESCRIPTION
### 작업 내용
- 공유드렸던 저장소를 참고해서 답변용 이슈 템플릿을 추가했습니다.
- 각 상황에 맞는 이슈 템플릿이 만들어져 있는데, 우리의 상황을 고려했을 때 2)에 해당하는 템플릿만 필요할 것 같습니다. 원래 템플릿은 [여기](https://github.com/Next-Squad/Interview-Question/blob/main/.github/ISSUE_TEMPLATE/core-topic-answer.md)를 확인해보시면 됩니다.
- 템플릿이 꼭 필요한 건 아닌 것 같지만, 이슈 만들 때마다 형식 찾아서 맞추기 번거로울 것 같다고 생각이 들어 추가하려고 합니다.
- 추가하거나 수정이 필요한 점이 있다면 알려주세요.

### 조사한 내용
- 살펴보니 이런 식으로 진행하는 것 같습니다.
  1) 주차별로 정한 주제에 대해서 질문 리스트를 만들고, [이슈](https://github.com/Next-Squad/Interview-Question/issues/54)로 추가한다
  2) 각 질문을 [이슈](https://github.com/Next-Squad/Interview-Question/issues/63)로 생성해서 답변을 적는다 <- PR에서 추가하는 템플릿이 여기에 해당합니다
  3) 만약 답변에 질문이 있다면, 이슈 내에서 댓글로 묻고 답한다 (확인해보니 질문은 따로 하시지는 않는 것 같네요)